### PR TITLE
Update long to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"node-cassandra-cql": "0.5.0",
 		"pluralize": "0.0.10",
         "node-uuid": "1.4.1",
-        "long": "1.1.5"
+        "long": "2.2.5"
 	},
 	"devDependencies": {
 		"mocha": "^1.20.1",


### PR DESCRIPTION
Updates long to the latest version. Without this a package that uses the newest version of long will run into interoperability issues when using cassie.types.Long.

Specifically `long.isLong(cassie.types.Long.fromString('123456789012345678'))` returns false due to version differences.

@Flux159 