### PR TITLE
Cassie ODM CQL 3.0 Supports

### DIFF
--- a/lib/cassie.js
+++ b/lib/cassie.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var async = require('async');
-var cql = require('node-cassandra-cql');
+var cql = require('./connection.js');
 
 //Cassie Dependencies:
 
@@ -69,7 +69,7 @@ exports.connect = function (config) {
     Cassie.hosts = config.hosts;
     Cassie.config = config;
 
-    var connection = new cql.Client(config);
+    var connection = cql.Client(config);
 
     if (!Cassie.connection) {
         Cassie.connection = connection;
@@ -142,7 +142,7 @@ exports.model = function (modelName, schema, options) {
 };
 
 exports.checkKeyspace = function (config, options, callback) {
-    var client = new cql.Client({hosts: config.hosts});
+    var client = cql.Client({hosts: config.hosts});
     Sync.checkKeyspaceExists(client, config.keyspace, config, options, function () {
         client.shutdown(callback);
     });
@@ -150,7 +150,7 @@ exports.checkKeyspace = function (config, options, callback) {
 
 var internalSyncTables = function (config, options, callback) {
 
-    var describeTablesQuery = "SELECT * FROM system.schema_columnfamilies WHERE keyspace_name=?";
+    var describeTablesQuery = "SELECT * FROM system_schema.tables WHERE keyspace_name=?";
     var describeTablesArguments = [Cassie.keyspace.toLowerCase()];
 
     var connection = (options.connection || Cassie.connection || null);
@@ -167,7 +167,6 @@ var internalSyncTables = function (config, options, callback) {
 
     query.exec(function (err, results) {
         if (err) {
-            console.log(err);
             throw "Cassie Error: There was an issue in obtaining table information when attempting to sync tables.";
         }
 
@@ -258,9 +257,11 @@ exports.syncTables = function (config, options, callback) {
         internalSyncTables(config, options, callback);
     } else {
         //For null and true, do the keyspace check
-        var client = new cql.Client({hosts: config.hosts});
+        var client = cql.Client({hosts: config.hosts});
         Sync.checkKeyspaceExists(client, config.keyspace, config, options, function () {
-            internalSyncTables(config, options, callback);
+            Sync.useKeyspace(client, config.keyspace, config, function(err) {
+              internalSyncTables(config, options, callback);
+            });
         });
     }
 
@@ -273,7 +274,7 @@ exports.syncTables = function (config, options, callback) {
  * @param callback (Required)
  */
 exports.deleteKeyspace = function(config, options, callback) {
-    var client = new cql.Client({hosts: config.hosts});
+    var client = cql.Client({hosts: config.hosts});
     Sync.deleteKeyspace(client, config.keyspace, options, callback);
 };
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -10,6 +10,10 @@ var CassandraConnection = {
     return this;
   },
   execute: function(query, params, options, callback) {
+    if (typeof options === 'function') {
+        callback = options;
+        options = {};
+    }
     // This function also runs a prepared statement because that is required in the new versions of cassandra driver
     // As it gives an error whenever int is used to conform to the Number type. Cassandra assumed an int to be double
     var overriddenOptions = Object.assign({}, options, {prepare: true});

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -31,6 +31,14 @@ var CassandraConnection = {
     db.execute(query, params, overriddenOptions, callback);
   },
   executeBatch: function(queryArray, connection, options, callback) {
+    if (options) {
+      options.prepare = true;
+    }
+    else {
+      options = {
+        prepare: true
+      };
+    }
     if (!queryArray || queryArray.length == 0) {
       return callback();
     }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -24,25 +24,19 @@ var CassandraConnection = {
     db.execute(query, params, overriddenOptions, callback);
   },
   stream: function(query, params, options, callback) {
-    return db.stream(query, params, options, callback);
+    var overriddenOptions = Object.assign({}, options, {prepare: true});
+    return db.stream(query, params, overriddenOptions, callback);
   },
   executePrepared: function(query, params, options, callback) {
     var overriddenOptions = Object.assign({}, options, {prepare: true});
     db.execute(query, params, overriddenOptions, callback);
   },
   executeBatch: function(queryArray, connection, options, callback) {
-    if (options) {
-      options.prepare = true;
-    }
-    else {
-      options = {
-        prepare: true
-      };
-    }
+    var overriddenOptions = Object.assign({}, options, {prepare: true});
     if (!queryArray || queryArray.length == 0) {
       return callback();
     }
-    db.batch(queryArray, options, callback);
+    db.batch(queryArray, overriddenOptions, callback);
   },
   shutdown: function(callback) {
     // The cassandra-driver does not have a close method for the db

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -10,7 +10,10 @@ var CassandraConnection = {
     return this;
   },
   execute: function(query, params, options, callback) {
-    db.execute(query, params, options, callback);
+    // This function also runs a prepared statement because that is required in the new versions of cassandra driver
+    // As it gives an error whenever int is used to conform to the Number type. Cassandra assumed an int to be double
+    var overriddenOptions = Object.assign({}, options, {prepare: true});
+    db.execute(query, params, overriddenOptions, callback);
   },
   stream: function(query, params, options, callback) {
     return db.stream(query, params, options, callback);
@@ -19,7 +22,7 @@ var CassandraConnection = {
     var overriddenOptions = Object.assign({}, options, {prepare: true});
     db.execute(query, params, overriddenOptions, callback);
   },
-  executeBatch: function(queryArray, options, callback) {
+  executeBatch: function(queryArray, connection, options, callback) {
     if (!queryArray || queryArray.length == 0) {
       return callback();
     }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -43,26 +43,10 @@ var CassandraConnection = {
       return callback();
     }
     db.batch(queryArray, options, callback);
-    // var batchedQuery = db.beginBatch();
-    // queryArray.forEach(function(queryObj, index) {
-      // var query = db.beginQuery();
-      // query.query(queryObj.query);
-      // query.params.forEach(function(param) {
-        // query.param(param);
-      // });
-      // batchedQuery.add(query);
-    // });
-    // batchedQuery
-      // .options(options)
-      // .timestamp()
-      // .execute(function(err) {
-        // console.log('error during batched query', err);
-      // })
-      // .done(callback);
   },
   shutdown: function(callback) {
+    // The cassandra-driver does not have a close method for the db
     callback();
-    // db.close(callback);
   }
 };
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -6,6 +6,9 @@ var CassandraConnection = {
     var overriddenOptions = config;
     // The old driver used to specify hosts as the field, this is changed to contactPoints. Hosts is used as config param for backward compatibility
     overriddenOptions.contactPoints = config.hosts;
+    if (config.keyspace) {
+      overriddenOptions.keyspace = config.keyspace.toLowerCase();
+    }
     db = new Cassandra.Client(overriddenOptions);
     return this;
   },

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,0 +1,50 @@
+var Cassandra = require('cassandra-driver') ;
+
+var db = null;
+var CassandraConnection = {
+  Client: function(config, options) {
+    var overriddenOptions = config;
+    // The old driver used to specify hosts as the field, this is changed to contactPoints. Hosts is used as config param for backward compatibility
+    overriddenOptions.contactPoints = config.hosts;
+    db = new Cassandra.Client(overriddenOptions);
+    return this;
+  },
+  execute: function(query, params, options, callback) {
+    db.execute(query, params, options, callback);
+  },
+  stream: function(query, params, options, callback) {
+    return db.stream(query, params, options, callback);
+  },
+  executePrepared: function(query, params, options, callback) {
+    var overriddenOptions = Object.assign({}, options, {prepare: true});
+    db.execute(query, params, overriddenOptions, callback);
+  },
+  executeBatch: function(queryArray, options, callback) {
+    if (!queryArray || queryArray.length == 0) {
+      return callback();
+    }
+    db.batch(queryArray, options, callback);
+    // var batchedQuery = db.beginBatch();
+    // queryArray.forEach(function(queryObj, index) {
+      // var query = db.beginQuery();
+      // query.query(queryObj.query);
+      // query.params.forEach(function(param) {
+        // query.param(param);
+      // });
+      // batchedQuery.add(query);
+    // });
+    // batchedQuery
+      // .options(options)
+      // .timestamp()
+      // .execute(function(err) {
+        // console.log('error during batched query', err);
+      // })
+      // .done(callback);
+  },
+  shutdown: function(callback) {
+    callback();
+    // db.close(callback);
+  }
+};
+
+module.exports = CassandraConnection;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -16,6 +16,7 @@ var CassandraConnection = {
     }
     // This function also runs a prepared statement because that is required in the new versions of cassandra driver
     // As it gives an error whenever int is used to conform to the Number type. Cassandra assumed an int to be double
+    // Recommended way of fixing this is preparing queries
     var overriddenOptions = Object.assign({}, options, {prepare: true});
     db.execute(query, params, overriddenOptions, callback);
   },

--- a/lib/query.js
+++ b/lib/query.js
@@ -96,13 +96,14 @@ function Query(queryString, params, connection, options, modelName) {
 
     //Fix/hack for map hints
     var mapIndex = -1;
-    this.params.forEach(function(param, index) {
-        if(typeof param === 'object' && !(param instanceof Array)) {
-            if(!param.low && !(param instanceof Date)) {
-                mapIndex = index;
-            }
-        }
-    });
+    // hinting is not required, as the queries are prepared, which is the recommended way of fixing the issue
+    // this.params.forEach(function(param, index) {
+        // if(typeof param === 'object' && !(param instanceof Array)) {
+            // if(!param.low && !(param instanceof Date)) {
+                // mapIndex = index;
+            // }
+        // }
+    // });
     if(mapIndex !== -1) {
         this.params[mapIndex] = {hint: 'map', value: this.params[mapIndex]};
     }

--- a/lib/query.js
+++ b/lib/query.js
@@ -97,13 +97,6 @@ function Query(queryString, params, connection, options, modelName) {
     //Fix/hack for map hints
     var mapIndex = -1;
     // hinting is not required, as the queries are prepared, which is the recommended way of fixing the issue
-    // this.params.forEach(function(param, index) {
-        // if(typeof param === 'object' && !(param instanceof Array)) {
-            // if(!param.low && !(param instanceof Date)) {
-                // mapIndex = index;
-            // }
-        // }
-    // });
     if(mapIndex !== -1) {
         this.params[mapIndex] = {hint: 'map', value: this.params[mapIndex]};
     }

--- a/lib/query.js
+++ b/lib/query.js
@@ -80,7 +80,7 @@ var cleanupExecOptions = function(execOptions, logger, queryString, params) {
         }
     }
 
-    if (!execOptions.consistency) {
+    if (!execOptions.consistency && typeof execOptions == 'object') {
         execOptions.consistency = types.consistencies.quorum;
     }
     return execOptions;
@@ -347,7 +347,7 @@ function Query(queryString, params, connection, options, modelName) {
 
         if(execOptions.prepare || execOptions.prepared) {
 
-            connection.executeAsPrepared(queryString, params, execOptions.consistency, function (err, results, metadata) {
+            connection.executePrepared(queryString, params, execOptions.consistency, function (err, results, metadata) {
                 if (execOptions.timing) {
                     var elapsed = process.hrtime(start);
                     var milli = elapsed[1] / 1000000; //millisecond time

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -223,7 +223,7 @@ exports.createTables = function (createTablesDictionary, connection, options, ca
 
     Object.keys(createTablesDictionary).forEach(function (tableName) {
 
-        var createTableQuery = "CREATE TABLE " + tableName + " (";
+        var createTableQuery = "CREATE TABLE IF NOT EXISTS " + tableName + " (";
         var primaryKeyString = "";
 
         var schema = createTablesDictionary[tableName];
@@ -351,7 +351,7 @@ exports.createTables = function (createTablesDictionary, connection, options, ca
 
         Object.keys(fieldsToAddIndex).forEach(function (indexField) {
             var indexName = tableName + "_" + indexField;
-            var createIndexString = "CREATE INDEX " + indexName + " ON " + tableName + " (" + indexField + ")";
+            var createIndexString = "CREATE INDEX IF NOT EXISTS " + indexName + " ON " + tableName + " (" + indexField + ")";
 
             seriesCalls.push(function (cb) {
 

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -87,6 +87,27 @@ exports.checkKeyspaceExists = function (client, keyspace, options, execOptions, 
     });
 };
 
+exports.useKeyspace = function(client, keyspace, options, callback) {
+    if (typeof options === 'function') {
+        callback = options;
+        options = {};
+    }
+
+    if(!keyspace) {
+        throw "cassie.useKeyspace must have config.keyspace defined. See documentation for more information.";
+    }
+
+    var queryString = "USE " + keyspace;
+
+    var query = new Query(queryString, [], client, options, null);
+
+    query.exec(function(err, results) {
+        client.shutdown(function() {
+            callback(err, results);
+        });
+    });
+};
+
 exports.deleteKeyspace = function(client, keyspace, options, callback) {
     if (typeof options === 'function') {
         callback = options;
@@ -365,7 +386,7 @@ exports.updateTables = function (updateTablesDictionary, connection, options, ca
 
     var describeSeriesCalls = [];
 
-    var keyspace = connection.options.keyspace;
+    var keyspace = connection.keyspace;
     Object.keys(updateTablesDictionary).forEach(function (tableName) {
 
         describeSeriesCalls.push(function (cb1) {

--- a/package.json
+++ b/package.json
@@ -1,43 +1,43 @@
 {
-	"author": "Suyog Sonwalkar",
-	"name": "cassie-odm",
-	"description": "ODM (Object Data Model) for Cassandra that uses node-cassandra-cql",
-	"version": "0.1.6",
-    "keywords": [
-        "cassandra",
-        "odm",
-        "cql",
-        "orm"
-    ],
-	"homepage": "http://Flux159.github.io/cassie-odm",
-    "bugs": "http://github.com/Flux159/cassie-odm/issues",
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/Flux159/cassie-odm.git"
-	},
-	"scripts": {
-		"test": "node node_modules/.bin/mocha \"test/**/*.js\"",
-        "test-coverage": "node node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -u exports -R spec test/**/*.js"
-	},
-	"engines": {
-		"node": ">=0.10.0"
-	},
-	"dependencies": {
-		"async": "0.9.0",
-		"node-cassandra-cql": "0.5.0",
-		"pluralize": "0.0.10",
-        "node-uuid": "1.4.1",
-        "long": "2.2.5"
-	},
-	"devDependencies": {
-		"mocha": "^1.20.1",
-        "istanbul": "^0.3.0"
-	},
-	"optionalDependencies": {},
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "https://github.com/Flux159/cassie-odm/raw/master/LICENSE.txt"
-		}
-	]
+  "author": "Suyog Sonwalkar",
+  "name": "cassie-odm",
+  "description": "ODM (Object Data Model) for Cassandra that uses node-cassandra-cql",
+  "version": "0.1.6",
+  "keywords": [
+    "cassandra",
+    "odm",
+    "cql",
+    "orm"
+  ],
+  "homepage": "http://Flux159.github.io/cassie-odm",
+  "bugs": "http://github.com/Flux159/cassie-odm/issues",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/Flux159/cassie-odm.git"
+  },
+  "scripts": {
+    "test": "node node_modules/.bin/mocha \"test/**/*.js\"",
+    "test-coverage": "node node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -u exports -R spec test/**/*.js"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "async": "0.9.0",
+    "cassandra-driver": "^3.1.1",
+    "long": "2.2.5",
+    "node-uuid": "1.4.1",
+    "pluralize": "0.0.10"
+  },
+  "devDependencies": {
+    "mocha": "^1.20.1",
+    "istanbul": "^0.3.0"
+  },
+  "optionalDependencies": {},
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/Flux159/cassie-odm/raw/master/LICENSE.txt"
+    }
+  ]
 }

--- a/test/integration/basic_integration_test.js
+++ b/test/integration/basic_integration_test.js
@@ -59,7 +59,7 @@ describe('Basic', function () {
         var options = {};
 //        var options = {debug: true, prettyDebug: true};
         cassie.syncTables(connectOptions, options, function (err, results) {
-            done();
+            done(err);
         });
     });
 
@@ -158,7 +158,7 @@ describe('Basic', function () {
                     Trick.find({id: trick.id}, function(err, results) {
 
                         assert(results[0].name === 'test');
-                        assert(results[0].id === trick.id);
+                        assert(results[0].id.toString() === trick.id.toString());
 
                         done();
                     });

--- a/test/integration/debug_integration_test.js
+++ b/test/integration/debug_integration_test.js
@@ -19,8 +19,8 @@ describe('Sync', function () {
                 var newCatSchema = new cassie.Schema({name: String, breed: String});
                 var Cat = cassie.model('Cat', newCatSchema);
 
-                cassie.syncTables(config, options, function () {
-                    done();
+                cassie.syncTables(config, options, function (err) {
+                    done(err);
                 });
 
             });
@@ -57,7 +57,7 @@ describe('Sync', function () {
                             var query2 = kitten2.remove();
 
                             cassie.batch([query1, query2], {debug: true, prettyDebug:true, timing: true}, function(err) {
-                                done();
+                                done(err);
                             });
                         });
                     });

--- a/test/readme/client_connections_test.js
+++ b/test/readme/client_connections_test.js
@@ -5,7 +5,7 @@ var cassie = require('../../lib/cassie');
 describe('Client Connections', function() {
 
     describe("find", function() {
-        it('should return -1 when the value is not present', function() {
+        it('should return -1 when the value is not present', function(done) {
 //            var cassie = require('cassie-odm');
             var cassie = require('../../lib/cassie');
             var connection = cassie.connect({keyspace: "CassieTest", hosts: ["127.0.0.1:9042"]});
@@ -13,6 +13,7 @@ describe('Client Connections', function() {
             connection.execute("SELECT * FROM cats", [], function(err, results) {
                 if(err) return console.log(err);
                 console.log("meow");
+                done(err);
             });
         });
     });


### PR DESCRIPTION
Using the new version of the cassandra driver (datastax/nodejs-driver) which has CQL 3.0 support and passed all npm tests. A few changes to tests are made, but no major rewrites.