### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -3,7 +3,7 @@
 /**
  * UUID Generator (v1 and v4) obtained from node-cassandra-cql types.js
  */
-var uuidGenerator = require('node-uuid');
+var uuidGenerator = require('uuid');
 
 /**
  * Long constructor, wrapper of the internal library used. obtained from node-cassandra-cql types.js

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "async": "0.9.0",
     "cassandra-driver": "3.1.1",
     "long": "2.2.5",
-    "node-uuid": "1.4.1",
-    "pluralize": "0.0.10"
+    "pluralize": "0.0.10",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "^1.20.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.