### PR TITLE
Minor Test Refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "test": "node_modules/.bin/mocha 'test/**/*.js'",
-    "test-coverage": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -u exports -R spec 'test/**/*.js'"
+    "test-coverage": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -u exports 'test/**/*.js'"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "url": "git://github.com/Flux159/cassie-odm.git"
   },
   "scripts": {
-    "test": "node node_modules/.bin/mocha \"test/**/*.js\"",
-    "test-coverage": "node node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -u exports -R spec test/**/*.js"
+    "test": "node_modules/.bin/mocha \"test/**/*.js\"",
+    "test-coverage": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -u exports -R spec test/**/*.js"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "test": "node_modules/.bin/mocha 'test/**/*.js'",
-    "test-coverage": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -u exports 'test/**/*.js'"
+    "test-coverage": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- 'test/**/*.js'"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "url": "git://github.com/Flux159/cassie-odm.git"
   },
   "scripts": {
-    "test": "node_modules/.bin/mocha \"test/**/*.js\"",
-    "test-coverage": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -u exports -R spec test/**/*.js"
+    "test": "node_modules/.bin/mocha 'test/**/*.js'",
+    "test-coverage": "node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -u exports -R spec 'test/**/*.js'"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test/cassieconnect.js
+++ b/test/cassieconnect.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  connectOptions: {
+    hosts: ['127.0.0.1:9042'],
+    keyspace: 'CassieTest'
+  },
+};

--- a/test/integration/basic_integration_test.js
+++ b/test/integration/basic_integration_test.js
@@ -43,16 +43,6 @@ cassie.model('Trick', TrickSchema);
 
 var ids = [];
 
-after(function (done) {
-    cassie.deleteKeyspace(connectOptions, function (err, results) {
-        cassie.close(function() {
-            cassie.closeAll(function() {
-                done();
-            });
-        });
-    });
-});
-
 describe('Basic', function () {
 
     before(function (done) {

--- a/test/integration/basic_integration_test.js
+++ b/test/integration/basic_integration_test.js
@@ -1,10 +1,9 @@
 var assert = require('assert');
 
+var connectOptions = require('../cassieconnect').connectOptions;
+
 var cassie = require('../../lib/cassie'),
     Schema = cassie.Schema;
-
-var connectOptions = {hosts: ["127.0.0.1:9042"], keyspace: "CassieTest"};
-cassie.connect(connectOptions);
 
 var TrickSchema = new Schema({'name': {type: String, index: true}});
 
@@ -39,13 +38,13 @@ TrickSchema.plugin(function (schema) {
     });
 }, {testing: 'options'});
 
-cassie.model('Trick', TrickSchema);
-
 var ids = [];
 
 describe('Basic', function () {
 
     before(function (done) {
+        cassie.model('Trick', TrickSchema);
+
         var options = {};
 //        var options = {debug: true, prettyDebug: true};
         cassie.syncTables(connectOptions, options, function (err, results) {

--- a/test/integration/crud_integration_test.js
+++ b/test/integration/crud_integration_test.js
@@ -1,11 +1,9 @@
 var assert = require('assert');
 
+var connectOptions = require('../cassieconnect').connectOptions;
+
 var cassie = require('../../lib/cassie'),
     Schema = cassie.Schema;
-
-var connectOptions = {hosts: ["127.0.0.1:9042"], keyspace: "CassieTest"};
-
-cassie.connect(connectOptions);
 
 var DogSchema = new Schema({
     'dog_id': {type: Number, primary: true},
@@ -13,16 +11,17 @@ var DogSchema = new Schema({
     'lname': String
 }, {sync: true});
 
-cassie.model('Dog', DogSchema);
-
-var Dog = cassie.model('Dog');
-
 describe('Crud', function () {
+  var Dog;
 
     before(function (done) {
+        cassie.model('Dog', DogSchema);
+
+        Dog = cassie.model('Dog');
+
         var options = {};
-        cassie.syncTables(connectOptions, options, function (err, results) {
-            done();
+        cassie.syncTables(connectOptions, options, function (err) {
+            done(err);
         });
     });
 

--- a/test/integration/debug_integration_test.js
+++ b/test/integration/debug_integration_test.js
@@ -1,8 +1,7 @@
 var assert = require('assert');
 
+var connectOptions = require('../cassieconnect').connectOptions;
 var cassie = require('../../lib/cassie');
-var config = {keyspace: "CassieTest", hosts: ["127.0.0.1:9042"]};
-cassie.connect(config);
 
 describe('Sync', function () {
 
@@ -14,12 +13,12 @@ describe('Sync', function () {
 
             var options = {debug: true, prettyDebug: true};
 
-            cassie.syncTables(config, options, function () {
+            cassie.syncTables(connectOptions, options, function () {
 
                 var newCatSchema = new cassie.Schema({name: String, breed: String});
                 var Cat = cassie.model('Cat', newCatSchema);
 
-                cassie.syncTables(config, options, function (err) {
+                cassie.syncTables(connectOptions, options, function (err) {
                     done(err);
                 });
 
@@ -36,7 +35,7 @@ describe('Sync', function () {
 //            var options = {debug: true, prettyDebug: true};
             var options = {};
 
-            cassie.syncTables(config, options, function () {
+            cassie.syncTables(connectOptions, options, function () {
 
                 var newCatSchema = new cassie.Schema({name: String, breed: String});
                 var Cat = cassie.model('Cat', newCatSchema);

--- a/test/integration/stream_integration_test.js
+++ b/test/integration/stream_integration_test.js
@@ -1,8 +1,7 @@
 var assert = require('assert');
 
+var connectOptions = require('../cassieconnect').connectOptions;
 var cassie = require('../../lib/cassie');
-var config = {keyspace: "CassieTest", hosts: ["127.0.0.1:9042"]};
-cassie.connect(config);
 
 describe("Queries", function () {
     it('Should insert, find, and batch remove (with debug)', function (done) {
@@ -12,7 +11,7 @@ describe("Queries", function () {
 
         var options = {};
 
-        cassie.syncTables(config, options, function () {
+        cassie.syncTables(connectOptions, options, function () {
 
             var newCatSchema = new cassie.Schema({name: String, breed: String});
             var Cat = cassie.model('Cat', newCatSchema);

--- a/test/integration/sync_integration_test.js
+++ b/test/integration/sync_integration_test.js
@@ -1,15 +1,14 @@
 var assert = require('assert');
 
+var connectOptions = require('../cassieconnect').connectOptions;
 var cassie = require('../../lib/cassie');
-var config = {keyspace: "CassieTest", hosts: ["127.0.0.1:9042"]};
-cassie.connect(config);
 
 describe('Sync', function () {
 
     describe("createKeyspace", function () {
         it('Should check or create a keyspace', function (done) {
-            cassie.checkKeyspace(config, function (err, results) {
-                done();
+            cassie.checkKeyspace(connectOptions, function (err) {
+                done(err);
             });
         });
     });
@@ -23,13 +22,13 @@ describe('Sync', function () {
 //            var options = {debug: true, prettyDebug: true};
             var options = {};
 
-            cassie.syncTables(config, options, function () {
+            cassie.syncTables(connectOptions, options, function () {
 
                 var newCatSchema = new cassie.Schema({name: String, breed: String});
                 var Cat = cassie.model('Cat', newCatSchema);
 
-                cassie.syncTables(config, options, function () {
-                    done();
+                cassie.syncTables(connectOptions, options, function (err) {
+                    done(err);
                 });
 
             });

--- a/test/setup.js
+++ b/test/setup.js
@@ -3,6 +3,11 @@
 var cassie = require('../lib/cassie');
 var connectOptions = require('./cassieconnect').connectOptions;
 
+
+before('Connect to Cassandra', function() {
+  cassie.connect(connectOptions);
+});
+
 after('Drop keyspace and Close', function (done) {
   this.timeout(10000);
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var cassie = require('../lib/cassie');
+var connectOptions = require('./cassieconnect').connectOptions;
+
+after('Drop keyspace and Close', function (done) {
+  this.timeout(10000);
+
+  cassie.deleteKeyspace(connectOptions, {}, function (err) {
+    if (err) return done(err);
+    cassie.close(function(err) {
+      if (err) return done(err);
+      cassie.closeAll(function(err) {
+        done(err);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR refactors the tests a small amount.

* _Make `npm test` and `npm run test-coverage` commands more consistent_: Each were using different mocha flags. The `npm run test-coverage` command was telling mocha to use a different syntax then the tests were written in which caused an issue when trying import a common configuration object.
* _Remove duplicate connection objects_:  Each integration test was hard coding `127.0.01` which is a requirement spelled out in the read me but we can apply DRY and move the connection object definition into a common module imported by each test. This makes it easier to do development if you do not have Cassandra installed locally.
* _Cut down on duplicate connects_: Move the root `after` hook out into a common module (`setup.js`) and create a root `before` hook to connect to Cassandra. This avoids connecting to Cassandra multiple times when the tests are loaded. Now we connect once when the tests are run.

**Note:** These changes are confined to the integration tests as I believe the intention of the read me tests is to have them as close to the way they show up in the read me (copy-n-paste) so I didn't want to touch them unless you are ok with me changing those tests too.

I tested these changes against Node v4, v6, and 8 and they all pass. I do not have a Node 0.10 setup.