### PR TITLE
Add Travis CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+sudo: required
+dist: trusty
+os: linux
+git:
+  depth: 1
+cache:
+  directories:
+    - "node_modules"
+services:
+  - cassandra
+node_js:
+  - '0.10'
+  - '4'
+  - '6'
+  - '8'
+  - '10'
+matrix:
+  allow_failures:
+    - node_js: '0.10'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,7 @@ cache:
 services:
   - cassandra
 node_js:
-  - '0.10'
   - '4'
   - '6'
   - '8'
   - '10'
-matrix:
-  allow_failures:
-    - node_js: '0.10'

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test-coverage": "node node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -u exports -R spec test/**/*.js"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4.9.1"
   },
   "dependencies": {
     "async": "0.9.0",


### PR DESCRIPTION
Travis CI ([travis-ci.org](https://travis-ci.org)) is a free hosted CI server which supports many
programing languages and platforms. It also has many services including
access to a Cassandra database.

To use Travis CI just define a .travis.yml file which outlines how to setup
your testing environment and how to run tests then allow Travis to monitor
your GitHub repo.

This change set adds a Travis-CI file which will run the test suite against
multiple versions of Node.

**Note**: Travis will run `npm install` and `npm test` by default for node
projects so this file is pretty light. It just defines that we need access to 
a Cassandra database and which version of node to run the tests against.

I picked each LTS version of Node from 0.10 as the `package.json` for this
project states that it can run on any version of Node from 0.10 and up; 
however I see that when run against Node 0.10 there are errors so this 
project probably does not work on Node 0.10 any more.

I have connected my fork to Travis you can see the test runs [here](https://travis-ci.org/bvanderlaan/cassie-odm)

You can see the current status via this badge: [![Build Status](https://travis-ci.org/bvanderlaan/cassie-odm.svg?branch=master)](https://travis-ci.org/bvanderlaan/cassie-odm)

I like using Travis and it will let the project be tested against multiple versions of Node automatically.