### PR TITLE
Add tests for types

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -30,17 +30,6 @@ function uuid(options, buffer, offset) {
     return uuidGenerator.v4(options, buffer, offset);
 }
 
-/**
- * Returns a long representation.
- * Used internally for deserialization obtained from node-cassandra-cql types.js
- */
-//Long.fromBuffer = function (value) {
-//    if (!(value instanceof Buffer)) {
-//        throw new TypeError('Expected Buffer', value, Buffer);
-//    }
-//    return new Long(value.readInt32BE(4), value.readInt32BE(0, 4));
-//};
-
 Long.fromString = function(value) {
     if(typeof value !== 'string') {
         throw new TypeError('Expected String', value, String);
@@ -55,20 +44,6 @@ Long.toString = function(obj) {
     var strlong = new long(obj);
     return strlong.toString();
 };
-
-/**
- * Returns a big-endian buffer representation of the Long instance obtained from node-cassandra-cql types.js
- * @param {Long} value
- */
-//Long.toBuffer = function (value) {
-//    if (!(value instanceof Long)) {
-//        throw new TypeError('Expected Long', value, Long);
-//    }
-//    var buffer = new Buffer(8);
-//    buffer.writeUInt32BE(value.getHighBitsUnsigned(), 0);
-//    buffer.writeUInt32BE(value.getLowBitsUnsigned(), 4);
-//    return buffer;
-//};
 
 /**
  * Int type - provides a hint to node-cassandra-cql to use an integer

--- a/lib/types.js
+++ b/lib/types.js
@@ -37,11 +37,16 @@ Long.fromString = function(value) {
     return new long.fromString(value);
 };
 
+/**
+ * @param {Number} obj.low The lower 32-bit part of the value
+ * @param {Number} obj.high The higher 32-bit part of the value
+ * @returns The string representation of the 64-bit integer
+ */
 Long.toString = function(obj) {
     if(typeof obj !== 'object') {
         throw new TypeError('Expected Object {low: lower-32 bits, high: higher-32 bits}', obj, Object);
     }
-    var strlong = new long(obj);
+    var strlong = new long(obj.low, obj.high);
     return strlong.toString();
 };
 

--- a/test/types.unit.js
+++ b/test/types.unit.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var assert = require('assert');
+
+var types = require('../lib/types');
+
+describe('Unit :: Types', function() {
+  describe('Long', function() {
+    describe('toString', function() {
+      it('should throw if not an object', function() {
+        assert.throws(function() {
+          types.datatypes.Long.toString('not an object');
+        }, /Expected Object/);
+      });
+
+      it('should convert object to string', function() {
+        var actual = types.datatypes.Long.toString({ low: 0xFFFFFFFF, high: 0x7FFFFFFF });
+        assert.equal(actual, '9223372036854775807');
+      });
+
+      it('should return -1 if value exceeds twos-complement 64-bits', function() {
+        var actual = types.datatypes.Long.toString({ low: 0xFFFFFFFF, high: 0xFFFFFFFF });
+        assert.equal(actual, '-1');
+      });
+    });
+  });
+});

--- a/test/types.unit.js
+++ b/test/types.unit.js
@@ -23,5 +23,25 @@ describe('Unit :: Types', function() {
         assert.equal(actual, '-1');
       });
     });
+
+    describe('fromString', function() {
+      it('should throw if not a string', function() {
+        assert.throws(function() {
+          types.datatypes.Long.fromString(123456789);
+        }, /Expected String/);
+      });
+
+      it('should convert string to complete actual value', function() {
+        // Storing this number in a Number would result in 9223372036854776000
+        // Using Long.fromString will ensure we get 9223372036854775807
+        var actual = types.datatypes.Long.fromString('9223372036854775807');
+        assert.equal(actual, 9223372036854775807);
+      });
+
+      it('should return negative value if exceeds twos-complement 64-bits', function() {
+        var actual = types.datatypes.Long.fromString('9223372036854775807009');
+        assert.equal(actual, '-991');
+      });
+    });
   });
 });

--- a/test/unit/types.unit.js
+++ b/test/unit/types.unit.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert');
 
-var types = require('../lib/types');
+var types = require('../../lib/types');
 
 describe('Unit :: Types', function() {
   describe('Long', function() {


### PR DESCRIPTION
This PR adds tests for the code in `types.js`
It uncovered one bug in the `Long.toString()` method and includes a fix for it.