### PR TITLE
✅Add tests for schema

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -51,7 +51,7 @@ function Schema(obj, options) {
 //    }
 
     var returnObj = {};
-    returnObj._fields = obj;
+    returnObj._fields = Object.assign({}, obj);
     returnObj._virtuals = {};
 
     returnObj._primary = determinePrimaryKey(obj);

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^1.20.1",
-    "istanbul": "^0.3.0"
+    "istanbul": "^0.3.0",
+    "sinon": "^6.3.5",
+    "sinon-chai": "^3.2.0"
   },
-  "optionalDependencies": {},
   "licenses": [
     {
       "type": "MIT",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "uuid": "3.0.0"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
     "mocha": "^1.20.1",
     "istanbul": "^0.3.0"
   },

--- a/test/integration/basic_integration_test.js
+++ b/test/integration/basic_integration_test.js
@@ -43,6 +43,8 @@ var ids = [];
 describe('Basic', function () {
 
     before(function (done) {
+        this.timeout(4000);
+
         cassie.model('Trick', TrickSchema);
 
         var options = {};

--- a/test/schema.unit.js
+++ b/test/schema.unit.js
@@ -1,0 +1,162 @@
+'use strict';
+
+var assert = require('assert');
+
+var types = require('../lib/types');
+var Schema = require('../lib/schema');
+
+describe('Unit :: Schema', function() {
+  describe('Sync', function() {
+    it('should default sync to true when no options', function() {
+      var model = {};
+      var schema = new Schema(model);
+      assert.equal(true, schema._sync);
+    });
+
+    it('should default sync to true when null', function() {
+      var model = {};
+      var schema = new Schema(model, { sync: null });
+      assert.equal(true, schema._sync);
+    });
+
+    it('should default sync to true when undefined', function() {
+      var model = {};
+      var schema = new Schema(model, { });
+      assert.equal(true, schema._sync);
+    });
+  });
+
+  describe('Primary key', function() {
+    it('should set the primary key to field when defined in field', function() {
+      var model = {
+        dog_id: { type: Number, primary: true }
+      };
+      var schema = new Schema(model);
+      assert.equal('dog_id', schema._primary);
+      assert.deepEqual(['dog_id'], schema._flatPrimaryList);
+    });
+
+    it('will over ride the primary key if also set in options as string', function() {
+      // Should it be doing this?
+      var model = {
+        dog_id: { type: Number, primary: true }
+      };
+      var options = {
+        primary: 'cat_id'
+      };
+      var schema = new Schema(model, options);
+      assert.equal('cat_id', schema._primary);
+      assert.deepEqual(['cat_id'], schema._flatPrimaryList);
+    });
+
+    it('should set the primary key when defined in options as array', function() {
+      var model = {
+        dog_id: { type: Number }
+      };
+      var options = {
+        primary: ['cat_id']
+      };
+      var schema = new Schema(model, options);
+      assert.equal('cat_id', schema._primary);
+
+      // Should this not be 'cat_id'? I think this a bug based on how _flatPrimaryList is used
+      assert.deepEqual([0], schema._flatPrimaryList);
+    });
+
+    it('should throw if primary key is set in both field and options as array', function() {
+      var model = {
+        dog_id: { type: Number, primary: true }
+      };
+      var options = {
+        primary: ['cat_id']
+      };
+
+      assert.throws(function() {
+        var schema = new Schema(model, options);
+      }, /Cannot specify multiple primary keys/);
+    });
+
+    it('should set the composite key', function() {
+      var model = {
+        dog_id: { type: Number }
+      };
+      var options = {
+        primary: ['dog_id', 'cat_id']
+      };
+      var schema = new Schema(model, options);
+      assert.deepEqual(['dog_id', 'cat_id'], schema._primary);
+
+      // Should this not be ['dog_id', 'cat_id']? I think this a bug based on how _flatPrimaryList is used
+      assert.deepEqual([0, 1], schema._flatPrimaryList);
+    });
+
+    it('should set the composite and partition keys', function() {
+      var model = {
+        dog_id: { type: Number }
+      };
+      var options = {
+        primary: [['dog_id', 'cat_id'], 'fish_id']
+      };
+      var schema = new Schema(model, options);
+      assert.deepEqual([['dog_id', 'cat_id'], 'fish_id'], schema._primary);
+
+      // Should this not be ['dog_id', 'cat_id', 'fish_id']? I think this a bug based on how _flatPrimaryList is used
+      assert.deepEqual([0, 1], schema._flatPrimaryList);
+    });
+
+    it('should set the primary key to id if none provided', function() {
+      var model = {
+        dog_id: { type: Number }
+      };
+      var options = {};
+      var schema = new Schema(model, options);
+      assert.equal('id', schema._primary);
+      assert.deepEqual(['id'], schema._flatPrimaryList);
+    });
+
+    it('should create id field if no primary key is provided', function() {
+      var model = {
+        dog_id: { type: Number }
+      };
+      var options = {};
+      var schema = new Schema(model, options);
+      assert.deepEqual({
+        type: types.datatypes.uuid,
+        primary: true,
+      }, schema._fields['id']);
+    });
+
+    it('should throw if id field exists and no primary key is provided', function() {
+      var model = {
+        id: { type: Number }
+      };
+      var options = {};
+      assert.throws(function() {
+        var schema = new Schema(model, options);
+      }, /must specify a primary key/)
+    });
+  });
+
+  describe('Fields', function () {
+    it('should set fields to the model fields', function () {
+      var model = {
+        dog_id: { type: Number, primary: true },
+        breed: { type: String }
+      };
+      var schema = new Schema(model);
+      assert.deepEqual(model, schema._fields);
+    });
+
+    it('should add a validator for each field', function () {
+      var model = {
+        dog_id: { type: Number, primary: true },
+        breed: { type: String }
+      };
+      var schema = new Schema(model);
+      assert.deepEqual({
+        dog_id: [],
+        breed: []
+      }, schema.validators);
+    });
+  });
+});

--- a/test/schema.unit.js
+++ b/test/schema.unit.js
@@ -197,4 +197,137 @@ describe('Unit :: Schema', function() {
         .which.equals('Field: dog_id is required.');
     });
   });
+
+  describe('Create Options', function () {
+    it('should set create options to undefined if not set', function () {
+      var model = {
+        dog_id: { type: Number, primary: true },
+        breed: { type: String }
+      };
+      var schema = new Schema(model);
+      expect(schema).to.have.property('_createOptions')
+        .which.is.undefined;
+    });
+
+    it('should set create options to if set', function () {
+      var model = {
+        dog_id: { type: Number, primary: true },
+        breed: { type: String }
+      };
+      var schema = new Schema(model, { create_options: 42 });
+      expect(schema).to.have.property('_createOptions')
+        .which.equals(42);
+    });
+  });
+
+  describe('PRE', function () {
+    var model = {
+      dog_id: { type: Number, primary: true },
+      breed: { type: String }
+    };
+    var hook = function () {};
+
+    it('should throw if invalid pre hook', function() {
+      // TODO: Should throw Error objects not strings
+      var schema = new Schema(model);
+      expect(function() {
+        schema.pre('invalid', hook)
+      }).to.throw(/only supports/);
+    });
+
+    it('should add a pre save hook', function() {
+      var schema = new Schema(model);
+      schema.pre('save', hook);
+      expect(schema).to.have.property('preFunctions')
+        .which.has.property('save')
+        .that.includes(hook);
+    });
+
+    it('should add a pre remove hook', function() {
+      var schema = new Schema(model);
+      schema.pre('remove', hook);
+      expect(schema).to.have.property('preFunctions')
+        .which.has.property('remove')
+        .that.includes(hook);
+    });
+  });
+
+  describe('POST', function () {
+    var model = {
+      dog_id: { type: Number, primary: true },
+      breed: { type: String }
+    };
+    var hook = function () {};
+
+    it('should throw if invalid post hook', function() {
+      // TODO: Should throw Error objects not strings
+      var schema = new Schema(model);
+      expect(function() {
+        schema.post('invalid', hook)
+      }).to.throw(/only supports/);
+    });
+
+    it('should add a post save hook', function() {
+      var schema = new Schema(model);
+      schema.post('save', hook);
+      expect(schema).to.have.property('postFunctions')
+        .which.has.property('save')
+        .that.includes(hook);
+    });
+
+    it('should add a post remove hook', function() {
+      var schema = new Schema(model);
+      schema.post('remove', hook);
+      expect(schema).to.have.property('postFunctions')
+        .which.has.property('remove')
+        .that.includes(hook);
+    });
+
+    it('should add a post validate hook', function() {
+      var schema = new Schema(model);
+      schema.post('validate', hook);
+      expect(schema).to.have.property('postFunctions')
+        .which.has.property('validate')
+        .that.includes(hook);
+    });
+
+    it('should add a post init hook', function() {
+      var schema = new Schema(model);
+      schema.post('init', hook);
+      expect(schema).to.have.property('postFunctions')
+        .which.has.property('init')
+        .that.includes(hook);
+    });
+  });
+
+  describe('Validate', function () {
+    var model = {
+      dog_id: { type: Number, primary: true },
+      breed: { type: String }
+    };
+    var validator = function () {};
+
+    it('should add validator to field', function() {
+      var schema = new Schema(model);
+      schema.validate('breed', validator, 'Breed is not cool enough');
+      expect(schema).to.have.property('validators');
+      expect(schema.validators).to.have.property('breed');
+      expect(schema.validators.breed[0]).to.have.property('func')
+        .and.is.a('function');
+      expect(schema.validators.breed[0]).to.have.property('str')
+        .which.equals('Breed is not cool enough');
+    });
+
+    it('should add validator to non-existing field', function() {
+      // TODO: Wonder if it should actually throw in this case
+      var schema = new Schema(model);
+      schema.validate('age', validator, 'Dog is to old');
+      expect(schema).to.have.property('validators');
+      expect(schema.validators).to.have.property('age');
+      expect(schema.validators.age[0]).to.have.property('func')
+        .and.is.a('function');
+      expect(schema.validators.age[0]).to.have.property('str')
+        .which.equals('Dog is to old');
+    });
+  });
 });

--- a/test/schema.unit.js
+++ b/test/schema.unit.js
@@ -330,4 +330,49 @@ describe('Unit :: Schema', function() {
         .which.equals('Dog is to old');
     });
   });
+
+  describe('Add', function () {
+    var model = {
+      dog_id: { type: Number, primary: true },
+      breed: { type: String }
+    };
+
+    it('should add a new field to the model', function () {
+      var schema = new Schema(model);
+      expect(schema).to.have.property('_fields')
+        .which.have.all.keys('dog_id', 'breed');
+
+      schema.add({ age: Number });
+      expect(schema).to.have.property('_fields')
+        .which.have.all.keys('dog_id', 'breed', 'age');
+      expect(schema._fields.age).to.equal(Number);
+    });
+
+    it('should not add field as primary', function () {
+      // TODO: Maybe we should throw here? Fail fast and all that
+      var schema = new Schema(model);
+      expect(schema).to.have.property('_fields')
+        .which.have.all.keys('dog_id', 'breed');
+
+      schema.add({ age: { type: Number, primary: true } });
+      expect(schema).to.have.property('_fields')
+        .which.have.all.keys('dog_id', 'breed', 'age');
+      expect(schema._fields.age).to.deep.equals({
+        type: Number,
+        primary: false
+      });
+    });
+
+    it('should over write existing fields', function () {
+      var schema = new Schema(model);
+      expect(schema).to.have.property('_fields')
+        .which.have.all.keys('dog_id', 'breed');
+      expect(schema._fields.breed).to.deep.equals({ type: String });
+
+      schema.add({ breed: { type: Number } });
+      expect(schema).to.have.property('_fields')
+        .which.have.all.keys('dog_id', 'breed');
+      expect(schema._fields.breed).to.deep.equals({ type: Number });
+    });
+  });
 });

--- a/test/schema.unit.js
+++ b/test/schema.unit.js
@@ -1,28 +1,30 @@
 'use strict';
 
-var assert = require('assert');
+var chai = require('chai');
 
 var types = require('../lib/types');
 var Schema = require('../lib/schema');
+
+var expect = chai.expect;
 
 describe('Unit :: Schema', function() {
   describe('Sync', function() {
     it('should default sync to true when no options', function() {
       var model = {};
       var schema = new Schema(model);
-      assert.equal(true, schema._sync);
+      expect(schema._sync).to.be.true;
     });
 
     it('should default sync to true when null', function() {
       var model = {};
       var schema = new Schema(model, { sync: null });
-      assert.equal(true, schema._sync);
+      expect(schema._sync).to.be.true;
     });
 
     it('should default sync to true when undefined', function() {
       var model = {};
       var schema = new Schema(model, { });
-      assert.equal(true, schema._sync);
+      expect(schema._sync).to.be.true;
     });
   });
 
@@ -32,8 +34,10 @@ describe('Unit :: Schema', function() {
         dog_id: { type: Number, primary: true }
       };
       var schema = new Schema(model);
-      assert.equal('dog_id', schema._primary);
-      assert.deepEqual(['dog_id'], schema._flatPrimaryList);
+      expect(schema, '_primary').to.have.property('_primary')
+        .which.equals('dog_id');
+      expect(schema, '_flatPrimaryList').to.have.property('_flatPrimaryList')
+        .which.deep.equals(['dog_id']);
     });
 
     it('will over ride the primary key if also set in options as string', function() {
@@ -45,8 +49,10 @@ describe('Unit :: Schema', function() {
         primary: 'cat_id'
       };
       var schema = new Schema(model, options);
-      assert.equal('cat_id', schema._primary);
-      assert.deepEqual(['cat_id'], schema._flatPrimaryList);
+      expect(schema, '_primary').to.have.property('_primary')
+        .which.equals('cat_id');
+      expect(schema, '_flatPrimaryList').to.have.property('_flatPrimaryList')
+        .which.deep.equals(['cat_id']);
     });
 
     it('should set the primary key when defined in options as array', function() {
@@ -57,10 +63,12 @@ describe('Unit :: Schema', function() {
         primary: ['cat_id']
       };
       var schema = new Schema(model, options);
-      assert.equal('cat_id', schema._primary);
+      expect(schema, '_primary').to.have.property('_primary')
+        .which.deep.equals(['cat_id']);
 
       // Should this not be 'cat_id'? I think this a bug based on how _flatPrimaryList is used
-      assert.deepEqual([0], schema._flatPrimaryList);
+      expect(schema, '_flatPrimaryList').to.have.property('_flatPrimaryList')
+        .which.deep.equals(['0']);
     });
 
     it('should throw if primary key is set in both field and options as array', function() {
@@ -71,9 +79,9 @@ describe('Unit :: Schema', function() {
         primary: ['cat_id']
       };
 
-      assert.throws(function() {
+      expect(function() {
         var schema = new Schema(model, options);
-      }, /Cannot specify multiple primary keys/);
+      }).to.throw(/Cannot specify multiple primary keys/);
     });
 
     it('should set the composite key', function() {
@@ -84,10 +92,12 @@ describe('Unit :: Schema', function() {
         primary: ['dog_id', 'cat_id']
       };
       var schema = new Schema(model, options);
-      assert.deepEqual(['dog_id', 'cat_id'], schema._primary);
+      expect(schema, '_primary').to.have.property('_primary')
+        .which.deep.equals(['dog_id', 'cat_id']);
 
       // Should this not be ['dog_id', 'cat_id']? I think this a bug based on how _flatPrimaryList is used
-      assert.deepEqual([0, 1], schema._flatPrimaryList);
+      expect(schema, '_flatPrimaryList').to.have.property('_flatPrimaryList')
+        .which.deep.equals(['0', '1']);
     });
 
     it('should set the composite and partition keys', function() {
@@ -98,10 +108,12 @@ describe('Unit :: Schema', function() {
         primary: [['dog_id', 'cat_id'], 'fish_id']
       };
       var schema = new Schema(model, options);
-      assert.deepEqual([['dog_id', 'cat_id'], 'fish_id'], schema._primary);
+      expect(schema, '_primary').to.have.property('_primary')
+        .which.deep.equals([['dog_id', 'cat_id'], 'fish_id']);
 
       // Should this not be ['dog_id', 'cat_id', 'fish_id']? I think this a bug based on how _flatPrimaryList is used
-      assert.deepEqual([0, 1], schema._flatPrimaryList);
+      expect(schema, '_flatPrimaryList').to.have.property('_flatPrimaryList')
+        .which.deep.equals(['0', '1']);
     });
 
     it('should set the primary key to id if none provided', function() {
@@ -110,8 +122,10 @@ describe('Unit :: Schema', function() {
       };
       var options = {};
       var schema = new Schema(model, options);
-      assert.equal('id', schema._primary);
-      assert.deepEqual(['id'], schema._flatPrimaryList);
+      expect(schema, '_primary').to.have.property('_primary')
+        .which.equals('id');
+      expect(schema, '_flatPrimaryList').to.have.property('_flatPrimaryList')
+        .which.deep.equals(['id']);
     });
 
     it('should create id field if no primary key is provided', function() {
@@ -120,10 +134,12 @@ describe('Unit :: Schema', function() {
       };
       var options = {};
       var schema = new Schema(model, options);
-      assert.deepEqual({
-        type: types.datatypes.uuid,
-        primary: true,
-      }, schema._fields['id']);
+      expect(schema).to.have.property('_fields')
+        .which.has.property('id')
+        .that.deep.equals({
+          type: types.datatypes.uuid,
+          primary: true,
+        });
     });
 
     it('should throw if id field exists and no primary key is provided', function() {
@@ -131,9 +147,9 @@ describe('Unit :: Schema', function() {
         id: { type: Number }
       };
       var options = {};
-      assert.throws(function() {
+      expect(function() {
         var schema = new Schema(model, options);
-      }, /must specify a primary key/)
+      }).to.throw(/must specify a primary key/);
     });
   });
 
@@ -144,7 +160,8 @@ describe('Unit :: Schema', function() {
         breed: { type: String }
       };
       var schema = new Schema(model);
-      assert.deepEqual(model, schema._fields);
+      expect(schema).to.have.property('_fields')
+        .which.deep.equals(model);
     });
 
     it('should add a validator for each field', function () {
@@ -153,10 +170,11 @@ describe('Unit :: Schema', function() {
         breed: { type: String }
       };
       var schema = new Schema(model);
-      assert.deepEqual({
-        dog_id: [],
-        breed: []
-      }, schema.validators);
+      expect(schema).to.have.property('validators')
+        .which.deep.equals({
+          dog_id: [],
+          breed: []
+        }, schema.validators);
     });
   });
 });

--- a/test/schema.unit.js
+++ b/test/schema.unit.js
@@ -26,6 +26,12 @@ describe('Unit :: Schema', function() {
       var schema = new Schema(model, { });
       expect(schema._sync).to.be.true;
     });
+
+    it('should set sync to false when specified', function() {
+      var model = {};
+      var schema = new Schema(model, { sync: false });
+      expect(schema._sync).to.be.false;
+    });
   });
 
   describe('Primary key', function() {
@@ -175,6 +181,20 @@ describe('Unit :: Schema', function() {
           dog_id: [],
           breed: []
         }, schema.validators);
+    });
+
+    it('should add default required validator for each required field', function () {
+      var model = {
+        dog_id: { type: Number, primary: true, required: true },
+        breed: { type: String },
+      };
+      var schema = new Schema(model);
+      expect(schema).to.have.property('validators');
+      expect(schema.validators).to.have.property('dog_id');
+      expect(schema.validators.dog_id[0]).to.have.property('func')
+        .and.is.a('function');
+      expect(schema.validators.dog_id[0]).to.have.property('str')
+        .which.equals('Field: dog_id is required.');
     });
   });
 });

--- a/test/schema.unit.js
+++ b/test/schema.unit.js
@@ -1,11 +1,14 @@
 'use strict';
 
 var chai = require('chai');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
 
 var types = require('../lib/types');
 var Schema = require('../lib/schema');
 
 var expect = chai.expect;
+chai.use(sinonChai);
 
 describe('Unit :: Schema', function() {
   describe('Sync', function() {
@@ -469,5 +472,34 @@ describe('Unit :: Schema', function() {
         });
     })
 
+  });
+
+  describe('Plugin', function () {
+    it('should throw if not a function', function () {
+      var model = {
+        dog_id: { type: Number, primary: true },
+        breed: { type: String }
+      };
+      var schema = new Schema(model);
+
+      expect(function () {
+        schema.plugin('oops');
+      }).to.throw(/must be a function/);
+    });
+
+    it('should invoke plugin function', function () {
+      var model = {
+        dog_id: { type: Number, primary: true },
+        breed: { type: String }
+      };
+      var plugin = sinon.stub();
+      var options = { hello: 'world' };
+
+      var schema = new Schema(model);
+      schema.plugin(plugin, options);
+
+      expect(plugin).to.have.been.calledOnce;
+      expect(plugin).to.have.been.calledWith(schema, options);
+    });
   });
 });

--- a/test/schema.unit.js
+++ b/test/schema.unit.js
@@ -47,7 +47,7 @@ describe('Unit :: Schema', function() {
     });
 
     it('will over ride the primary key if also set in options as string', function() {
-      // Should it be doing this?
+      // TODO: Should it be doing this?
       var model = {
         dog_id: { type: Number, primary: true }
       };
@@ -374,5 +374,100 @@ describe('Unit :: Schema', function() {
         .which.have.all.keys('dog_id', 'breed');
       expect(schema._fields.breed).to.deep.equals({ type: Number });
     });
+  });
+
+  describe('Add Query', function () {
+    var model = {
+      dog_id: { type: Number, primary: true },
+      breed: { type: String }
+    };
+
+    it('should not add the query if not a function', function () {
+      // TODO: Should this not throw?
+      var schema = new Schema(model);
+      schema.addQuery({ get: 42 });
+      expect(schema).to.have.property('_addQueries')
+        .which.deep.equals({});
+    });
+
+    it('should add custom query', function () {
+      var get = function() {};
+      var schema = new Schema(model);
+      schema.addQuery({ get: get });
+      expect(schema).to.have.property('_addQueries')
+        .which.has.property('get')
+        .that.equals(get);
+    });
+  });
+
+  describe('Index', function () {
+    //TODO: If index is invalid we just log, should we not throw?
+
+    it('should set field\'s index to true', function() {
+      var model = {
+        dog_id: { type: Number, primary: true },
+        breed: { type: String }
+      };
+      var schema = new Schema(model);
+      schema.index('breed');
+      expect(schema).to.have.property('_fields')
+        .which.has.property('breed')
+        .that.has.property('index')
+        .which.is.true;
+    });
+
+    it('should set field\'s index to true when field is just Type', function() {
+      var model = {
+        dog_id: { type: Number, primary: true },
+        breed: String
+      };
+      var schema = new Schema(model);
+      schema.index('breed');
+      expect(schema).to.have.property('_fields')
+        .which.has.property('breed')
+        .that.has.property('index')
+        .which.is.true;
+    });
+  });
+
+  describe('Virtual', function () {
+    // TODO: If field does not exist we just log, should we rather throw in this case?
+    // TODO: If we forget to pass in the virtual function we just log, should we throw??
+
+    it('should add the virtual field', function () {
+      var model = {
+        dog_id: { type: Number, primary: true },
+        breed: { type: String }
+      };
+      var field = function () {}
+
+      var schema = new Schema(model);
+      schema.virtual('name', field);
+
+      expect(schema).to.have.property('_virtuals')
+        .which.has.property('name')
+        .that.has.property('get')
+        .which.equals(field);
+    });
+
+    it('should add the virtual field with getter and setter', function () {
+      var model = {
+        dog_id: { type: Number, primary: true },
+        breed: { type: String }
+      };
+      var get = function () {}
+      var set = function () {}
+
+      var schema = new Schema(model);
+      schema.virtual('name', { get: get, set: set });
+
+      expect(schema).to.have.property('_virtuals')
+        .which.has.property('name')
+        .that.deep.equals({
+          get: get,
+          set: set
+        });
+    })
+
   });
 });

--- a/test/unit/schema.unit.js
+++ b/test/unit/schema.unit.js
@@ -4,8 +4,8 @@ var chai = require('chai');
 var sinon = require('sinon');
 var sinonChai = require('sinon-chai');
 
-var types = require('../lib/types');
-var Schema = require('../lib/schema');
+var types = require('../../lib/types');
+var Schema = require('../../lib/schema');
 
 var expect = chai.expect;
 chai.use(sinonChai);


### PR DESCRIPTION
This PR adds tests for the Schema class.

I think I have uncovered a bug where the `_flatPrimaryList` is storing numbers (i.e. `"0"`) vs. the field names. I can push a PR to fix that bug later.

I also found that if you defined the primary key in the options object as a string we don't throw if you also define a field as primary, we just over ride the field. However if you set the primary key in the options as an array then we'd throw if the field was also set. Seems like an unintended inconsistency what do you think?

I identified other odd behaviours while writing the tests, I marked them with a TODO comment.

If so I can push a PR for that too.

**Note:** I added the `chai` assertion library in this PR as it just has more nice to use APIs for asserting which just made it easier to check objects attached on the Schema object.

**Note:** I added the `sinon` and `sinon-chai` modules, sinon is a mocking library and sinon-chai is a plugin for chai which adds new APIs to the chai assertion library which can check sinon to tell if the mocked out function was called and with which parameters.