### PR TITLE
 🐛Fix concatenation bug when sort by more then one field

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -184,9 +184,9 @@ function Query(queryString, params, connection, options, modelName) {
             appendLimit = true;
         }
 
-        var sortString = " ";
+        var sortString = "";
         for (var key in sortObject) {
-            sortString = sortString + key.toString() + " ";
+            sortString = sortString + " " + key.toString() + " ";
             if (sortObject[key] === 1) {
                 sortString = sortString + "ASC";
             } else if (sortObject[key] === -1) {
@@ -195,6 +195,7 @@ function Query(queryString, params, connection, options, modelName) {
                 throw "Sorting can only be ASCENDING (1) or DESCENDING (-1). See documentation on sort for more information.";
             }
         }
+        sortString = sortString.trim();
 
         //ORDER BY clause
         _this.queryString = _this.queryString + " ORDER BY " + sortString + " ";


### PR DESCRIPTION
If you use the sort API on the Query object with more then one field to
sort by the code was not concatenating the string together correctly.

This change set ensures that the second field is inserted with a leading
white space.

This bug was uncovered by https://github.com/Flux159/cassie-odm/pull/17
After making the fix I re-ran those tests and the bug has gone away.